### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Getting Help
 ============
 
 Documentation for django-transaction-hooks is available at
-https://django-transaction-hooks.readthedocs.org/
+https://django-transaction-hooks.readthedocs.io/
 
 This app is available on `PyPI`_ and can be installed with ``pip install
 django-transaction-hooks``.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -206,8 +206,8 @@ If you use `South`_, you will probably need to set the
 (e.g. to ``{'default': 'south.db.postgresql_psycopg2'}``, if you are using
 PostgreSQL).
 
-.. _South: http://south.readthedocs.org
-.. _SOUTH_DATABASE_ADAPTERS: http://south.readthedocs.org/en/latest/settings.html#south-database-adapters
+.. _South: https://south.readthedocs.io
+.. _SOUTH_DATABASE_ADAPTERS: https://south.readthedocs.io/en/latest/settings.html#south-database-adapters
 
 
 Use in tests


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.