### PR TITLE
Fix on_commit execution order when callbacks make transactions

### DIFF
--- a/transaction_hooks/mixin.py
+++ b/transaction_hooks/mixin.py
@@ -32,12 +32,11 @@ class TransactionHooksDatabaseWrapperMixin(object):
 
     def run_and_clear_commit_hooks(self):
         self.validate_no_atomic_block()
-        try:
-            while self.run_on_commit:
-                sids, func = self.run_on_commit.pop(0)
-                func()
-        finally:
-            self.run_on_commit = []
+        current_run_on_commit = self.run_on_commit
+        self.run_on_commit = []
+        while current_run_on_commit:
+            sids, func = current_run_on_commit.pop(0)
+            func()
 
     def commit(self, *a, **kw):
         super(TransactionHooksDatabaseWrapperMixin, self).commit(*a, **kw)


### PR DESCRIPTION
Backport of django/django@a5c8072ab1e56da368a40f3e9c9a3b465f4ffbae